### PR TITLE
Add new categories to gamemode metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Minigames
+
 ## End of Life
+
+### March 2021 - Categories Update
+
+The [March 2021 Garry's Mode Update](https://store.steampowered.com/news/app/4000/view/2988675197234811880) adds support for gamemode categories on the server browser. I've quickly whipped up a [1.3.11 update](https://github.com/fluffy-servers/minigames_v2/releases/tag/1.3.11) which adds these categories to the Minigames gamemodes.
+
+Also relevant - check out [the guide on how to use the proxy gamemode](https://github.com/fluffy-servers/minigames_v2/wiki/Server-Setup#proxy-gamemode) to keep your server stable in the server browser.
+
+### So long, and thanks for all the fish
+
 Fluffy Servers has come to a close and, while I'd love to keep pouring my heart into Minigames, I don't have the time or passion to maintain this project like I used to. No further content is expected for Minigames.
 
 If you're still making content for Minigames, please feel free to open a PR and I'll get around to reviewing it. If there's any developer features or tweaks you'd like made to the base, get in touch.
@@ -7,14 +17,17 @@ If you're still making content for Minigames, please feel free to open a PR and 
 I'd like to thank everyone who played Minigames on Fluffy Servers in the three years we were running - special thanks to everyone who helped create content. Minigames has been a fantastic learning experience for me, and I hope that if you're reading this README that you can still find some value out of this project.
 
 ## Introduction
+
 Minigames is a collection of exciting gamemodes developed by Fluffy Servers. We have new and original content, as well as remakes of gamemodes from the glory days of Fretta.
 
 The original Minigames ran from November 2017 until April 2018. It was then revived in it's current form in November 2018, aiming to be a more polished experienced with even more gamemodes and original maps.
 
 ## Special Thanks
+
 Please see CONTRIBUTORS.md for a comprehensive list of those who have helped out with the development of Minigames.
 
 ## Getting Started
+
 To setup a server, or start a local game with friends, see the [Server Setup page](https://github.com/fluffy-servers/minigames_v2/wiki/Server-Setup).
 
 If you're interested in learning how to map for Minigames, see the [Mapper's Guide page](https://github.com/fluffy-servers/minigames_v2/wiki/Mapper's-Guide).

--- a/gamemodes/fluffy_balls/fluffy_balls.txt
+++ b/gamemodes/fluffy_balls/fluffy_balls.txt
@@ -1,5 +1,6 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Ballz"
+	"base"		"fluffy_mg_base"
+	"title"		"Ballz"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_bombtag/fluffy_bombtag.txt
+++ b/gamemodes/fluffy_bombtag/fluffy_bombtag.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Bomb Tag"
-    "maps"	"^bt_"
+	"base"		"fluffy_mg_base"
+	"title"		"Bomb Tag"
+    "maps"		"^bt_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_classics/fluffy_classics.txt
+++ b/gamemodes/fluffy_classics/fluffy_classics.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Classics"
-	"maps"	"^mg_"
+	"base"		"fluffy_mg_base"
+	"title"		"Classics"
+	"maps"		"^mg_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_climb/fluffy_climb.txt
+++ b/gamemodes/fluffy_climb/fluffy_climb.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Climb!"
-    "maps"	"^climb_"
+	"base"		"fluffy_mg_base"
+	"title"		"Climb!"
+    "maps"		"^climb_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_cratewars/fluffy_cratewars.txt
+++ b/gamemodes/fluffy_cratewars/fluffy_cratewars.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Crate Wars 2"
-	"maps"	"^cw_"
+	"base"		"fluffy_mg_base"
+	"title"		"Crate Wars 2"
+	"maps"		"^cw_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_ctf/fluffy_ctf.txt
+++ b/gamemodes/fluffy_ctf/fluffy_ctf.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Capture The Flag"
-    "maps"	"^ctf_"
+	"base"		"fluffy_mg_base"
+	"title"		"Capture The Flag"
+    "maps"		"^ctf_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_dodgeball/fluffy_dodgeball.txt
+++ b/gamemodes/fluffy_dodgeball/fluffy_dodgeball.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_base"
-	"title"	"Dodgeball"
-    "maps"	"^db_"
+	"base"		"fluffy_base"
+	"title"		"Dodgeball"
+    "maps"		"^db_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_duckhunt/fluffy_duckhunt.txt
+++ b/gamemodes/fluffy_duckhunt/fluffy_duckhunt.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Duck Hunt"
-    "maps"	"^dh_"
+	"base"		"fluffy_mg_base"
+	"title"		"Duck Hunt"
+    "maps"		"^dh_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_freezetag/fluffy_freezetag.txt
+++ b/gamemodes/fluffy_freezetag/fluffy_freezetag.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_base"
-	"title"	"Freeze Tag"
-    "maps"	"^ft_"
+	"base"		"fluffy_base"
+	"title"		"Freeze Tag"
+    "maps"		"^ft_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_gungame/fluffy_gungame.txt
+++ b/gamemodes/fluffy_gungame/fluffy_gungame.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Gun Game"
-    "maps" "^gg_"
+	"base"		"fluffy_mg_base"
+	"title"		"Gun Game"
+    "maps" 		"^gg_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_incoming/fluffy_incoming.txt
+++ b/gamemodes/fluffy_incoming/fluffy_incoming.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Incoming!"
-    "maps"	"^inc_"
+	"base"		"fluffy_mg_base"
+	"title"		"Incoming!"
+    "maps"		"^inc_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_infection/fluffy_infection.txt
+++ b/gamemodes/fluffy_infection/fluffy_infection.txt
@@ -1,5 +1,6 @@
 "minigames"
 {
-	"base"	"fluffy_base"
-	"title"	"Infection"
+	"base"		"fluffy_base"
+	"title"		"Infection"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_junkjoust/fluffy_junkjoust.txt
+++ b/gamemodes/fluffy_junkjoust/fluffy_junkjoust.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_base"
-	"title"	"Junk Joust"
-    "maps"	"^jj_"
+	"base"		"fluffy_base"
+	"title"		"Junk Joust"
+    "maps"		"^jj_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_kingmaker/fluffy_kingmaker.txt
+++ b/gamemodes/fluffy_kingmaker/fluffy_kingmaker.txt
@@ -1,5 +1,6 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Kingmaker"
+	"base"		"fluffy_mg_base"
+	"title"		"Kingmaker"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_knockback/fluffy_knockback.txt
+++ b/gamemodes/fluffy_knockback/fluffy_knockback.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_base"
-	"title"	"Knockback"
-    "maps"	"^kb_"
+	"base"		"fluffy_base"
+	"title"		"Knockback"
+    "maps"		"^kb_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_laserdance/fluffy_laserdance.txt
+++ b/gamemodes/fluffy_laserdance/fluffy_laserdance.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Laser Dance"
-	"maps"	"^ld_"
+	"base"		"fluffy_mg_base"
+	"title"		"Laser Dance"
+	"maps"		"^ld_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_lava/fluffy_lava.txt
+++ b/gamemodes/fluffy_lava/fluffy_lava.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Lava"
-    "maps"	"^lava_"
+	"base"		"fluffy_mg_base"
+	"title"		"Lava"
+    "maps"		"^lava_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_mg_base/fluffy_mg_base.txt
+++ b/gamemodes/fluffy_mg_base/fluffy_mg_base.txt
@@ -1,6 +1,5 @@
-"minigames"
+"fluffy_mg_base"
 {
 	"base"	"base"
 	"title"	"Minigames"
-    "maps"	"^pvp_"
 }

--- a/gamemodes/fluffy_mg_base/fluffy_mg_base.txt
+++ b/gamemodes/fluffy_mg_base/fluffy_mg_base.txt
@@ -1,5 +1,5 @@
 "fluffy_mg_base"
 {
 	"base"	"base"
-	"title"	"Minigames"
+	"title"	"Minigames Base"
 }

--- a/gamemodes/fluffy_microgames/fluffy_microgames.txt
+++ b/gamemodes/fluffy_microgames/fluffy_microgames.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Microgames"
-    "maps"	"^micro_"
+	"base"		"fluffy_mg_base"
+	"title"		"Microgames"
+    "maps"		"^micro_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_oitc/fluffy_oitc.txt
+++ b/gamemodes/fluffy_oitc/fluffy_oitc.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"One In The Chamber"
-	"maps"	"^oitc_"
+	"base"		"fluffy_mg_base"
+	"title"		"One In The Chamber"
+	"maps"		"^oitc_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_paintball/fluffy_paintball.txt
+++ b/gamemodes/fluffy_paintball/fluffy_paintball.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Paintball"
-    "maps"	"^pb_"
+	"base"		"fluffy_mg_base"
+	"title"		"Paintball"
+    "maps"		"^pb_"
+	"category" 	"pvp"
 }

--- a/gamemodes/fluffy_pitfall/fluffy_pitfall.txt
+++ b/gamemodes/fluffy_pitfall/fluffy_pitfall.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Pitfall"
-    "maps"	"^til_, ^pf_"
+	"base"		"fluffy_mg_base"
+	"title"		"Pitfall"
+    "maps"		"^til_, ^pf_"
+	"category"	"pvp"
 }

--- a/gamemodes/fluffy_poltergeist/fluffy_poltergeist.txt
+++ b/gamemodes/fluffy_poltergeist/fluffy_poltergeist.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Poltergeist"
-    "maps"	"^pg_"
+	"base"		"fluffy_mg_base"
+	"title"		"Poltergeist"
+    "maps"		"^pg_"
+	"category"	"pvp"
 }

--- a/gamemodes/fluffy_shotguns/fluffy_shotguns.txt
+++ b/gamemodes/fluffy_shotguns/fluffy_shotguns.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_base"
-	"title"	"Super Shotguns"
-    "maps"	"^sg_"
+	"base"		"fluffy_base"
+	"title"		"Super Shotguns"
+    "maps"		"^sg_"
+	"category"	"pvp"
 }

--- a/gamemodes/fluffy_sniperwars/fluffy_sniperwars.txt
+++ b/gamemodes/fluffy_sniperwars/fluffy_sniperwars.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_base"
-	"title"	"Sniper Wars"
-    "maps"	"^sw_"
+	"base"		"fluffy_base"
+	"title"		"Sniper Wars"
+    "maps"		"^sw_"
+	"category"	"pvp"
 }

--- a/gamemodes/fluffy_spectrum/fluffy_spectrum.txt
+++ b/gamemodes/fluffy_spectrum/fluffy_spectrum.txt
@@ -1,5 +1,6 @@
 "minigames"
 {
-	"base"	"fluffy_base"
-	"title"	"Spectrum"
+	"base"		"fluffy_base"
+	"title"		"Spectrum"
+	"category"	"pvp"
 }

--- a/gamemodes/fluffy_suicidebarrels/fluffy_suicidebarrels.txt
+++ b/gamemodes/fluffy_suicidebarrels/fluffy_suicidebarrels.txt
@@ -1,6 +1,7 @@
 "minigames"
 {
-	"base"	"fluffy_mg_base"
-	"title"	"Suicide Barrels"
-	"maps"	"^sb_"
+	"base"		"fluffy_mg_base"
+	"title"		"Suicide Barrels"
+	"maps"		"^sb_"
+	"category"	"pvp"
 }

--- a/gamemodes/minigames/minigames.txt
+++ b/gamemodes/minigames/minigames.txt
@@ -2,5 +2,6 @@
 {
 	"base"		"base"
 	"title"		"Minigames"
+	"maps"		"^mg_, ^pvp_"
 	"category"	"pvp"
 }

--- a/gamemodes/minigames/minigames.txt
+++ b/gamemodes/minigames/minigames.txt
@@ -1,5 +1,6 @@
 "minigames"
 {
-	"base"	"base"
-	"title"	"Minigames"
+	"base"		"base"
+	"title"		"Minigames"
+	"category"	"pvp"
 }


### PR DESCRIPTION
The [March 2021 Garry's Mode Update](https://store.steampowered.com/news/app/4000/view/2988675197234811880) adds support for gamemode categories on the server browser. 

This PR adds the **pvp** category to all gamemodes, and also applies some minor tidying to the Base & Proxy files.